### PR TITLE
Add claim filter module with CLI

### DIFF
--- a/apps/fact-checker/claim_filter/README.md
+++ b/apps/fact-checker/claim_filter/README.md
@@ -1,0 +1,27 @@
+# Claim Filter
+
+This module provides a lightweight agent that classifies individual claims by how certain they appear to be.
+It can be used as a standalone component to quickly filter large sets of claims before running the heavier
+fact‑checking pipeline.
+
+## Categories
+
+Claims are sorted into five certainty levels:
+
+1. **CERTAIN_TRUE** – Very strong evidence the claim is true.
+2. **PROBABLY_TRUE** – Likely true but not absolutely certain.
+3. **UNSURE** – Not enough information to judge either way.
+4. **PROBABLY_FALSE** – Likely false or misleading.
+5. **CERTAIN_FALSE** – Clearly false based on known information.
+
+## CLI Usage
+
+A helper script `filter_claims.py` is provided. It classifies each claim from an input file and outputs only the
+claims whose category matches the provided `--keep` values.
+
+```bash
+poetry run filter-claims input.json output.json --keep CERTAIN_TRUE,PROBABLY_TRUE
+```
+
+The input can be a JSON array, a CSV file with a `claim` column, or a plain text file with one claim per line.
+The output is written in the same format as the input.

--- a/apps/fact-checker/claim_filter/__init__.py
+++ b/apps/fact-checker/claim_filter/__init__.py
@@ -1,0 +1,12 @@
+"""Claim Filter - Categorize claims by certainty level."""
+
+from claim_filter.agent import create_graph, graph
+from claim_filter.schemas import ClaimCategory, ClaimFilterState, CategorizedClaim
+
+__all__ = [
+    "create_graph",
+    "graph",
+    "ClaimCategory",
+    "ClaimFilterState",
+    "CategorizedClaim",
+]

--- a/apps/fact-checker/claim_filter/agent.py
+++ b/apps/fact-checker/claim_filter/agent.py
@@ -1,0 +1,29 @@
+import logging
+
+from dotenv import load_dotenv
+from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from claim_filter.nodes import classify_claim_node
+from claim_filter.schemas import ClaimFilterState
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def create_graph() -> CompiledStateGraph:
+    """Create the claim filter workflow graph."""
+    workflow = StateGraph(ClaimFilterState)
+
+    workflow.add_node("classify_claim_node", classify_claim_node)
+    workflow.set_entry_point("classify_claim_node")
+    workflow.set_finish_point("classify_claim_node")
+
+    return workflow.compile()
+
+
+graph = create_graph()

--- a/apps/fact-checker/claim_filter/config/__init__.py
+++ b/apps/fact-checker/claim_filter/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration placeholders for claim filter."""

--- a/apps/fact-checker/claim_filter/llm/config.py
+++ b/apps/fact-checker/claim_filter/llm/config.py
@@ -1,0 +1,4 @@
+"""LLM configuration for claim filtering."""
+
+MODEL_NAME = "openai:o3"
+DEFAULT_TEMPERATURE = 0.0

--- a/apps/fact-checker/claim_filter/llm/models.py
+++ b/apps/fact-checker/claim_filter/llm/models.py
@@ -1,0 +1,14 @@
+"""LLM model helpers for claim filtering."""
+
+from langchain.chat_models import init_chat_model
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from claim_filter.llm.config import MODEL_NAME, DEFAULT_TEMPERATURE
+
+# Default LLM instance
+openai_llm = init_chat_model(model=MODEL_NAME, temperature=DEFAULT_TEMPERATURE)
+
+
+def get_llm() -> BaseChatModel:
+    """Return a new LLM instance with default settings."""
+    return init_chat_model(model=MODEL_NAME, temperature=DEFAULT_TEMPERATURE)

--- a/apps/fact-checker/claim_filter/nodes/__init__.py
+++ b/apps/fact-checker/claim_filter/nodes/__init__.py
@@ -1,0 +1,5 @@
+"""Export claim filter nodes."""
+
+from .classify_claim import classify_claim_node
+
+__all__ = ["classify_claim_node"]

--- a/apps/fact-checker/claim_filter/nodes/classify_claim.py
+++ b/apps/fact-checker/claim_filter/nodes/classify_claim.py
@@ -1,0 +1,47 @@
+"""Node that classifies a claim into a certainty category."""
+
+import logging
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+from claim_filter.llm import get_llm
+from claim_filter.schemas import ClaimCategory, ClaimFilterState
+from utils.llm import call_llm_with_structured_output
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """You categorize factual claims based on how likely they are to be true.\nReturn only the category name."""
+
+HUMAN_PROMPT = "Claim: \"{claim}\""
+
+
+class ClassificationOutput(BaseModel):
+    """Structured output for the classification LLM call."""
+
+    category: ClaimCategory = Field(description="Chosen category")
+
+
+async def classify_claim_node(state: ClaimFilterState) -> Dict[str, ClaimCategory]:
+    """Classify a claim using an LLM."""
+
+    claim = state.claim
+    llm = get_llm()
+
+    messages = [
+        ("system", SYSTEM_PROMPT),
+        ("human", HUMAN_PROMPT.format(claim=claim)),
+    ]
+
+    response = await call_llm_with_structured_output(
+        llm=llm,
+        output_class=ClassificationOutput,
+        messages=messages,
+        context_desc=f"claim classification for '{claim}'",
+    )
+
+    if not response:
+        logger.warning("LLM failed to classify claim, defaulting to UNSURE")
+        return {"category": ClaimCategory.UNSURE}
+
+    return {"category": response.category}

--- a/apps/fact-checker/claim_filter/schemas.py
+++ b/apps/fact-checker/claim_filter/schemas.py
@@ -1,0 +1,32 @@
+"""Data models for the claim filter."""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ClaimCategory(str, Enum):
+    """Categories used to label claims by certainty."""
+
+    CERTAIN_TRUE = "CERTAIN_TRUE"
+    PROBABLY_TRUE = "PROBABLY_TRUE"
+    UNSURE = "UNSURE"
+    PROBABLY_FALSE = "PROBABLY_FALSE"
+    CERTAIN_FALSE = "CERTAIN_FALSE"
+
+
+class CategorizedClaim(BaseModel):
+    """A claim with its assigned category."""
+
+    claim: str = Field(description="The claim text")
+    category: ClaimCategory = Field(description="Assigned category")
+
+
+class ClaimFilterState(BaseModel):
+    """State object for the claim filter graph."""
+
+    claim: str = Field(description="Claim to categorize")
+    category: Optional[ClaimCategory] = Field(
+        default=None, description="Resulting category after classification"
+    )

--- a/apps/fact-checker/pyproject.toml
+++ b/apps/fact-checker/pyproject.toml
@@ -26,3 +26,4 @@ package-mode = false
 
 [tool.poetry.scripts]
 create-run = "scripts.create_run:main"
+filter-claims = "scripts.filter_claims:main"

--- a/apps/fact-checker/scripts/filter_claims.py
+++ b/apps/fact-checker/scripts/filter_claims.py
@@ -1,0 +1,77 @@
+import argparse
+import asyncio
+import csv
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from claim_filter import graph as claim_filter_graph
+from claim_filter.schemas import ClaimCategory
+
+
+def read_claims(path: Path) -> List[str]:
+    if path.suffix.lower() == ".json":
+        with path.open() as f:
+            return json.load(f)
+    if path.suffix.lower() == ".csv":
+        with path.open(newline="") as f:
+            reader = csv.DictReader(f)
+            field = "claim" if "claim" in reader.fieldnames else reader.fieldnames[0]
+            return [row[field] for row in reader]
+    with path.open() as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def write_claims(path: Path, claims: Iterable[str]) -> None:
+    if path.suffix.lower() == ".json":
+        with path.open("w") as f:
+            json.dump(list(claims), f, indent=2)
+        return
+    if path.suffix.lower() == ".csv":
+        with path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["claim"])
+            for claim in claims:
+                writer.writerow([claim])
+        return
+    with path.open("w") as f:
+        for claim in claims:
+            f.write(claim + "\n")
+
+
+async def classify(claims: Iterable[str]) -> List[ClaimCategory]:
+    results = []
+    for claim in claims:
+        result = await claim_filter_graph.ainvoke({"claim": claim})
+        results.append(result.get("category"))
+    return results
+
+
+def parse_keep(value: str) -> List[ClaimCategory]:
+    parts = [v.strip() for v in value.split(",") if v.strip()]
+    return [ClaimCategory[p] for p in parts]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Classify and filter claims")
+    parser.add_argument("input_file", type=Path)
+    parser.add_argument("output_file", type=Path)
+    parser.add_argument(
+        "--keep",
+        required=True,
+        help="Comma-separated list of categories to keep",
+    )
+    args = parser.parse_args()
+
+    claims = read_claims(args.input_file)
+    keep_categories = parse_keep(args.keep)
+
+    categories = asyncio.run(classify(claims))
+
+    kept = [claim for claim, cat in zip(claims, categories) if cat in keep_categories]
+
+    write_claims(args.output_file, kept)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement new `claim_filter` package for categorizing claims
- include LLM configuration, node, agent, and data models
- add CLI script `filter_claims.py` and register it with Poetry
- document usage and categories in `claim_filter/README.md`

## Testing
- `python -m compileall -q apps/fact-checker`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb0924ef8832e8b5f2adf9fabcaea